### PR TITLE
Add support for cern

### DIFF
--- a/algorithms/datatools.py
+++ b/algorithms/datatools.py
@@ -22,7 +22,10 @@ def make_data_matrix(all_files, max_files=50, masking99 = False, sort_by='none')
             continue
         
         if ifile == 0:
-            sig_keys = [ vv.decode("utf-8") for vv in np.array(this_file['signal_keys']) ]
+            sig_keys = [ vv for vv in np.array(this_file['signal_keys']) ]
+            if type(sig_keys[0]) is bytes:
+                for i in range(len(sig_keys)):
+                    sig_keys[i] = sig_keys[i].decode("utf-8", "ignore")
             
     
         signals.append( np.array( this_file['signals'] ) )

--- a/algorithms/exec_train_cern.sh
+++ b/algorithms/exec_train_cern.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+SIM="/Data/ML/si-mu-lator/simulation_data"
+CARD="atlas_nsw_pad_z0_normalRate"
+DATA_LOC="${SIM}/${CARD}_bkgr_1/*.h5"
+#SING_IMG=/Data/images/slac-ml@20211101.0.sif
+SING_IMG=/Data/images/hls4ml_sandbox
+DET="../cards/${CARD}.yml"
+
+
+singularity exec -B /Data ${SING_IMG} python train.py -f "${DATA_LOC}" -m "tcn" --task "classification" --detector ${DET}
+
+# TCN with padded matrix for classification 
+# singularity exec -B /sdf,/gpfs,/scratch ${SING_IMG} python train.py -f "${DATA_LOC}" -m "tcn" --task "classification"
+
+# TCN with detector matrix for classification
+# singularity exec -B /sdf,/gpfs,/scratch ${SING_IMG} python train.py -f "${DATA_LOC}" -m "tcn" --task "classification" --detector ${DET}
+
+# TCN with padded matrix for classification and X regression
+# singularity exec -B /sdf,/gpfs,/scratch ${SING_IMG} python train.py -f "${DATA_LOC}" -m "tcn" --task "regression" --lambda 1  # --detector ${DET}
+
+# LSTM with detector matrix for classification
+# singularity exec -B /sdf,/gpfs,/scratch ${SING_IMG} python train.py -f "${DATA_LOC}" -m "lstm" --task "classification" --detector ${DET}

--- a/batch_slac/run_batch.py
+++ b/batch_slac/run_batch.py
@@ -7,14 +7,19 @@ njobs=200
 iseed=datetime.now().microsecond
 
 ## setup
-here_batch      = os.getcwd() + '/'
-here            = here_batch.replace('/batch_slac', '')
-#detcard_name    = "atlas_nsw_pad_z0" # for signal generation
-detcard_name    = "atlas_nsw_pad_z0_stgBkg20_stgMaxBkgHit1" # for background generation
-det_card        = here+"/cards/"+detcard_name+".yml"
+#here_batch      = os.getcwd() + '/'
+script_dir       = os.path.abspath( os.path.dirname( __file__ ) )
+root_dir         = script_dir.replace('/batch_slac', '')
+#detcard_name    = "atlas_mm_road"
+#detcard_name    = "atlas_nsw_vmm"
+#detcard_name    = "atlas_nsw_pad_z0"
+#detcard_name    = "atlas_nsw_pad_z0_stgc20"
+#detcard_name    = "atlas_nsw_pad_z0_stgc20Max1"
+detcard_name    = "atlas_nsw_pad_z0_normalRate"
+det_card        = root_dir+"/cards/"+detcard_name+".yml"
 
 ## events and noise
-nevs            = 2500
+nevs            = 2000
 bkg_rate        = 1
 override_total_n_noise = -1 ## only accepted if not generating muon
 #det_noise_dict = " --minhitsdet stgc 5 "
@@ -23,30 +28,53 @@ det_noise_dict = ""
 ## muon
 generate_muon   = False
 muon_x_range    = [-20.0,20.0]
-# muon_a_range    = [-3*1e-3, 3*1e-3]
-do_cov_angle    = True
-muon_a_range    = []
+muon_a_range    = [-3*1e-3, 3*1e-3]
+do_cov_angle    = False
+#muon_a_range    = []
 
-out_loc         = here_batch+f"/out_files/{detcard_name}_bkgr_{bkg_rate}"
+import subprocess
+result = subprocess.run(['hostname', '-d'], stdout=subprocess.PIPE)
+domain = result.stdout.decode('utf-8').split('\n')[0]
+if 'cern' in domain:
+#    out_loc         = script_dir +f"/out_files/{detcard_name}_bkgr_{bkg_rate}"
+    out_loc         =f"/Data/ML/si-mu-lator/simulation_data/{detcard_name}_bkgr_{bkg_rate}"
+else:
+    out_loc         = script_dir+f"/out_files/{detcard_name}_bkgr_{bkg_rate}"
 
 if not generate_muon and override_total_n_noise > 0:
-    out_loc += f'_override_{override_total_n_noise}/'
+    out_loc += f'_override_{override_total_n_noise}'
 else:
-    out_loc += '/'
+    out_loc += ''
 
 if not os.path.exists(out_loc):
   os.makedirs(out_loc)
   print("The new directory is created!")
 
-exec_file =  '''#!/bin/bash
+if 'slac' in domain:
+    
+    exec_file =  '''#!/bin/bash
 
 SINGULARITY_IMAGE_PATH=/sdf/sw/ml/slac-ml/20200227.0/slac-jupyterlab@20200227.0.sif
 
-singularity exec --nv -B /sdf,/gpfs,/scratch,/lscratch ${SINGULARITY_IMAGE_PATH} python _HERE_/si_mu_late.py _OPTIONS_ -r $1 _det_noise_
+singularity exec --nv -B /sdf,/gpfs,/scratch,/lscratch ${SINGULARITY_IMAGE_PATH} python _ROOTDIR_/si_mu_late.py _OPTIONS_ -r $1 _det_noise_
+'''
+elif 'cern' in domain:
+    exec_file =  '''#!/bin/bash                                                                                                                                      
 
+SINGULARITY_IMAGE_PATH=/Data/images/slac-jupyterlab@20200227.0.sif                                                                                                        
+
+singularity exec  -B /Data ${SINGULARITY_IMAGE_PATH} python _ROOTDIR_/si_mu_late.py _OPTIONS_ -r $1 _det_noise_
+ '''
+else:
+        exec_file =  '''#!/bin/bash                                                                                                                                     
+
+SINGULARITY_IMAGE_PATH=/your/sing/image                                                                                                              
+
+singularity exec --nv  ${SINGULARITY_IMAGE_PATH} python _ROOTDIR_/si_mu_late.py _OPTIONS_ -r $1 _det_noise_       
 '''
 
-exec_file = exec_file.replace("_HERE_", here)
+    
+exec_file = exec_file.replace("_ROOTDIR_", root_dir)
 exec_file = exec_file.replace("_det_noise_", det_noise_dict)
 base_name = f"{detcard_name}.nevs_{nevs}.bkgr_{bkg_rate}"
 
@@ -83,7 +111,7 @@ else:
         options += f" --override-n-noise-hits-per-event {override_total_n_noise} --minhits {override_total_n_noise} "
 
 exec_file = exec_file.replace("_OPTIONS_", options)
-exec_file_name = here+base_name+".sh"
+exec_file_name = root_dir+base_name+".sh"
 
 runf = open(exec_file_name, 'w')
 runf.write(exec_file)
@@ -96,14 +124,20 @@ for ir in range(iseed, iseed+njobs):
     torun = f"{exec_file_name} {ir} "
 
     batch_exec  = f"sbatch --partition=usatlas --job-name={jname} "
-    batch_exec += f"--output={here_batch}/logs/{jname}_o.txt "
-    batch_exec += f"--error={here_batch}/logs/{jname}_e.txt "
+    batch_exec += f"--output={script_dir}/logs/{jname}_o.txt "
+    batch_exec += f"--error={script_dir}/logs/{jname}_e.txt "
     batch_exec += f"--ntasks=1 --cpus-per-task=12 --mem-per-cpu=1g "
     batch_exec += f"--time=10:00:00 {torun}"
 
     print(batch_exec)
     # break
-    os.system(batch_exec)
+    if 'slac' in domain:
+        os.system(batch_exec)
+    elif 'cern' in domain:
+        print ("#INFO: using cern resources, no sbatch, so running each job sequentially")
+        os.system(torun)
+    else:
+        print ("#WARNING: Not a recognized environment, doing nothing")
     # break
 
 

--- a/hls4ml/batch/exec_do_hls_things_cern.sh
+++ b/hls4ml/batch/exec_do_hls_things_cern.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#SING_IMG=/Data/images/rnn_hls_keras_rnn_staticswitch_Apr25_viv_RR #use for LSTM and GRU only. can be used also to build using image's vivado
+SING_IMG=/Data/images/hls4ml_sandbox
+SING_VIVADO_ONLY_IMG=/Data/images/hls4ml.0.6.0_vivado.sif # remember it has hls4ml=0.5.1 do not use it, only for vivado
+#SING_IMG=/Data/images/muon_hls4ml_05072022.sif
+#SING_IMG=/Data/images/rnn_hls_keras_rnn_staticswitch_Apr25_RR_hls4ml.0.6.0
+#tot_width=( 12 14 16 18 )
+#int_width=( 2 4 6 8  )
+#r_factor=( 1 )
+
+fra_width=( 8 )
+int_width=( 12 )
+r_factor=( 10 )
+
+MOD_LOC=/afs/cern.ch/user/r/rrojas/public/ML/si-mu-lator/algorithms/models
+# MOD=gru_BatchNormTrue_MaskingFalse_28062022_06.21.52
+# MOD=lstm_BatchNormTrue_MaskingFalse_28062022_10.27.00
+# MOD=lstm_BatchNormFalse_MaskingFalse_29062022_00.09.58
+#MOD=gru_BatchNormFalse_MaskingFalse_11072022_16.56.28
+#MOD=tcn_BatchNormFalse_MaskingFalse_classification_21072022_16.11.06_detMatrix
+MOD=tcn_BatchNormFalse_MaskingFalse_classification_21072022_17.14.41_detMatrix
+
+DATALOC=/afs/cern.ch/user/r/rrojas/public/ML/si-mu-lator/hls4ml/
+DATA="${DATALOC}/X_test_10000.npy,${DATALOC}/Y_test_10000.npy"
+
+OUTD=/Data/Muon_hls/
+STRAT="Latency"
+STATIC=1
+export SINGULARITYENV_CPLUS_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+export SINGULARITYENV_C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu
+export SINGULARITYENV_LM_LICENSE_FILE=2112@licenxilinx
+function usage()
+{
+    echo "usage: exec_do_jls_things.sh [-s,v,a]"
+    echo "    -s synchronize between umassminipc02 and umasscastor1n1"
+    echo "    -v run vivado_hls csim, synth and vivado cosim, vsynth, export"
+    echo "    -a use vivado accelerator, create project and produce the bitfile"
+    echo "    -h this help"
+    exit 0
+}
+while getopts vash opt
+do
+    case "${opt}" in
+        v) VIVADO=1;;
+        a) ACCELERATOR=1;;
+        s) SYNC=1;;
+        h|*) usage;;
+    esac
+done
+    
+
+for fw in "${fra_width[@]}"
+do
+    for iw in "${int_width[@]}"
+    do
+        for rf in "${r_factor[@]}"
+        do
+            jname=${MOD}_${tw}_${iw}_${rf}
+            
+
+#!/bin/sh
+if [[ ! -z $SYNC ]];
+then
+    if [ $(hostname) == "umasscastor1n1" ]; then
+        echo "INFO: here will first sync the directory from umassminipc02 to local computer (umasscastor1n1):"
+        echo "     ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static"
+        rsync -av --progress umassminipc02:${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static ${OUTD}${MOD}
+    elif [ $(hostname) == "umassminipc02" ]; then
+        echo "INFO: here will first sync the directory from umasscastor1n1 to local computer (umassminipc02):"
+        echo "     ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static"
+        rsync -av --progress umasscastor1n1:${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static ${OUTD}${MOD}
+    else
+        echo "WARNING: the hostname does not match any of the recorded pc names"
+    fi
+fi;
+
+if [[ ! -z $VIVADO ]];
+then
+    echo "INFO: here will do vivado things only using:"
+    echo "     $SING_IMG"
+    echo "INFO: on the directory:"
+    echo "     ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static"
+
+    export SINGULARITYENV_PREPEND_PATH=/opt/Xilinx/Vivado/Vivado/2019.2/bin/
+    singularity exec -C -e  -H /home/rrojas/hls4ml_home -B /Data,/afs   ${SING_VIVADO_ONLY_IMG} /bin/bash -c "cd ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static/myproject_prj;"' vivado_hls -f build_prj.tcl "csim=1 synth=1 vsynth=1 cosim=1 export=1"'
+    #"cd ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static/myproject_prj;"
+    #' vivado_hls -f build_prj.tcl "csim=1 synth=0 cosim=0 export=0"'
+    
+fi;
+
+if [[ ! -z $ACCELERATOR ]];
+then
+    echo "INFO: here will do vivado accelerator only using:"
+    echo "     $SING_IMG"
+    echo "INFO: on the directory:"
+    echo "     ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static"
+    
+    export SINGULARITYENV_PREPEND_PATH=/opt/Xilinx/Vivado/Vivado/2019.2/bin/
+    singularity exec -C -e  -H /home/rrojas/hls4ml_home -B /Data,/afs   ${SING_VIVADO_ONLY_IMG} /bin/bash -c "cd ${OUTD}${MOD}/model_$(( ${fw} + ${iw})).${iw}_reuse_${rf}_${STRAT}_Static/myproject_prj;"' vivado -mode batch -source  project.tcl design.tcl'
+
+
+fi;
+
+if [[ (-z $ACCELERATOR) && (-z $VIVADO) && (-z $SYNC)]]
+then
+    #if no argument do the initial plan
+    singularity exec -C -e  -H /home/rrojas/hls4ml_home -B /Data,/afs,/tools   ${SING_IMG}  python -d /afs/cern.ch/user/r/rrojas/public/ML/si-mu-lator/hls4ml/batch/do_hls_things.py --name ${MOD} -a ${MOD_LOC}/${MOD}/arch.json -w ${MOD_LOC}/${MOD}/weights.h5 -d "${DATA}" -o ${OUTD} --fwidth ${fw} --iwidth ${iw} -r ${rf} --strategy ${STRAT} --static ${STATIC} --vivado #-t #-b #-t
+    
+fi;
+            
+        done
+    done
+done

--- a/hls4ml/exec_make_small_dataset.sh
+++ b/hls4ml/exec_make_small_dataset.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-SING_IMG=/sdf/group/ml/software/images/slac-ml/20211101.0/slac-ml@20211101.0.sif
+if [ $(hostname -d) == "slac.stanford.edu" ]; then
+    SING_IMG=/sdf/group/ml/software/images/slac-ml/20211101.0/slac-ml@20211101.0.sif
 
-singularity exec -B /sdf,/gpfs,/scratch ${SING_IMG} python make_small_dataset.py
+    singularity exec -B /sdf,/gpfs,/scratch ${SING_IMG} python make_small_dataset.py
+fi;
+
+if [ $(hostname -d) == "dyndns.cern.ch" ]; then
+    SING_IMG=/Data/images/slac-ml@20211101.0.sif
+
+    singularity exec -B /Data ${SING_IMG} python make_small_dataset.py
+fi;

--- a/hls4ml/make_small_dataset.py
+++ b/hls4ml/make_small_dataset.py
@@ -10,8 +10,17 @@ import trainingvariables
 from glob import glob
 from sklearn.utils import shuffle
 
-files_loc = "/gpfs/slac/atlas/fs1/d/rafaeltl/public/Muon/simulation/stgc/"
-# fdir = "atlas_mm_vmm_bkgr_1_TEST"
+import subprocess
+result = subprocess.run(['hostname', '-d'], stdout=subprocess.PIPE)
+domain = result.stdout.decode('utf-8').split('\n')[0]
+if 'slac' in domain:
+    files_loc = "/gpfs/slac/atlas/fs1/d/rafaeltl/public/Muon/simulation/stgc/"
+elif 'cern' in domain:
+    files_loc = "/Data/ML/si-mu-lator/simulation_data/"
+else:
+    print ("#ERROR: not a recognized environment, doing nothing")
+    exit(0)
+    # fdir = "atlas_mm_vmm_bkgr_1_TEST"
 fdir = "atlas_nsw_pad_z0_stgc20Max1_bkgr_1_CovAngle_TRAIN"
 nevs=100000
 do_det_matrix=False

--- a/patch/hls4ml/axi_stream_design.tcl.patch
+++ b/patch/hls4ml/axi_stream_design.tcl.patch
@@ -1,0 +1,12 @@
+4c4
+< 
+---
+> set target_lang "vhdl"
+6c6
+< 
+---
+> set_property target_language $target_lang [current_project]
+50c50
+< add_files -norecurse ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.v
+---
+> add_files -norecurse ./${myproject}_vivado_accelerator/project_1.srcs/sources_1/bd/design_1/hdl/design_1_wrapper.vhd

--- a/patch/hls4ml/build_prj.tcl.patch
+++ b/patch/hls4ml/build_prj.tcl.patch
@@ -1,0 +1,20 @@
+59c59
+< add_files -tb myproject_test.cpp -cflags "-std=c++0x"
+---
+> add_files -tb myproject_test.cpp -cflags "-std=c++0x" -csimflags "-I/usr/include/x86_64-linux-gnu"
+76c76
+<   csim_design
+---
+>   csim_design -ldflags "-B /usr/lib/x86_64-linux-gnu"
+92c92
+<   add_files -tb myproject_test.cpp -cflags "-std=c++0x -DRTL_SIM"
+---
+>   add_files -tb myproject_test.cpp -cflags "-std=c++0x -DRTL_SIM -I/usr/include/x86_64-linux-gnu"
+94c94
+<   cosim_design -trace_level all
+---
+>   cosim_design -trace_level all -ldflags "-B /usr/lib/x86_64-linux-gnu" -rtl vhdl
+116c116
+<   export_design -format ip_catalog
+---
+>   export_design -format ip_catalog -rtl vhdl

--- a/patch/hls4ml/nnet_activation_stream.h.patch
+++ b/patch/hls4ml/nnet_activation_stream.h.patch
@@ -1,0 +1,44 @@
+54a55,88
+> // ************************************************* 
+> //       RELU Activation with reshape capability    
+> // *************************************************
+> //   This implementation assumes that the size of the output is larger 
+> // or equal to the size of the in put, which is generally true for a Relu.
+> //   This relu can deal with reshape from one layer to another.
+> 
+> template<class data_T, class res_T, typename CONFIG_T>
+> void relu(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+>     #pragma HLS function_instantiate variable=res
+>     res_T data_m;
+>     ReLUActLoop: for (int i = 0; i < CONFIG_T::n_in / data_T::size; i++) {
+>     	if (CONFIG_T::n_in / data_T::size > 1){
+> 	    #pragma HLS PIPELINE
+>     	}	
+>     	data_T in_data = data.read();
+>     	res_T out_data;
+> 
+>   	ReLuReadLoop: for (int k = 0; k < data_T::size; k++){
+>             data_m[((i * data_T::size) + k) % res_T::size] = in_data[k];
+>             if ((((i * data_T::size) + k + 1) % res_T::size) == 0 ){
+>         	#pragma HLS DATA_PACK variable=out_data
+>             	ReLUPackLoop: for (int j = 0; j <  res_T::size; j++) {
+> 		    #pragma HLS UNROLL
+>             	    if (data_m[j] > 0) out_data[j] = data_m[j];
+>             	    else out_data[j] = 0;
+>                 }
+>             res.write(out_data);
+>             }
+>         }
+>     }
+> }
+> 
+> 
+59c93
+< void relu(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+---
+> void relu_backup(hls::stream<data_T> &data, hls::stream<res_T> &res) {
+643c677
+< #endif
+\ No newline at end of file
+---
+> #endif

--- a/patch/patch_hls4ml.sh
+++ b/patch/patch_hls4ml.sh
@@ -1,0 +1,46 @@
+# bash
+
+INSTALLATION_PATH="/srv/conda/envs/notebook/lib/python3.7/site-packages"
+
+function usage()
+{
+    echo "patch_hls4ml.sh"
+    echo "patch script to adapt few hls4ml files for ML project needs"
+    echo "usage: patch_hls4ml.sh [-i,d]"
+    echo "    -i Installation directory of hls4ml (default: ${INSTALLATION_PATH})"
+    echo "    -d dryrun, do not excecute, just print"
+    echo "    -h this help"
+    exit 0
+}
+while getopts i:dh opt
+do
+    case "${opt}" in
+        i) INSTALLATION_PATH=${OPTARG};;
+        d) DRYRUN=1;;
+        h|*) usage;;
+    esac
+done
+
+
+N_PATCHES=3
+PATCH_DIR="hls4ml"
+P_FILES=( "build_prj.tcl"
+	 "axi_stream_design.tcl"
+	 "nnet_activation_stream.h" )
+	 
+P_PATHS=( "hls4ml/templates/vivado"
+	  "hls4ml/templates/vivado_accelerator/zcu102/tcl_scripts"
+	  "hls4ml/templates/vivado/nnet_utils" )
+
+for (( i=0; i<N_PATCHES; i++)); do
+    F_tb_patch="${INSTALLATION_PATH}/${P_PATHS[i]}/${P_FILES[i]}"
+    patch="${PATCH_DIR}/${P_FILES[i]}.patch"
+    echo "INFO#: going to patch $F_tb_patch with ${patch}"
+    cmd="patch $F_tb_patch ${patch}"
+    if [ -z $DRYRUN ]; then 
+	$cmd
+    else
+	echo dryrun: $cmd
+    fi
+done
+    


### PR DESCRIPTION
The first commit adds support for CERN computing resources.
Determine if you are running from SLAC or CERN and change some file locations.
add scripts to run from CERN
list:
	modified:   algorithms/datatools.py
	new file:   algorithms/exec_train_cern.sh
	modified:   batch_slac/run_batch.py
	modified:   hls4ml/batch/do_hls_things.py
	new file:   hls4ml/batch/exec_do_hls_things_cern.sh
	modified:   hls4ml/exec_make_small_dataset.sh
	modified:   hls4ml/make_small_dataset.py

The second commit adds a patch for hls4ml version 0.6.0 
It will change default settings for our convenience and allow relu to operate as Flatten layer.
list: 
	new file:   patch/hls4ml/axi_stream_design.tcl.patch
	new file:   patch/hls4ml/build_prj.tcl.patch
	new file:   patch/hls4ml/nnet_activation_stream.h.patch
	new file:   patch/patch_hls4ml.sh
